### PR TITLE
setup: remove six dependency during setup

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include nlgeval *

--- a/README.md
+++ b/README.md
@@ -32,8 +32,6 @@ Python 2.7 has also been tested with mostly the same dependencies but an older v
 
 For the initial one-time setup, make sure java 1.8.0 is installed. After that just run:
     
-    pip install six
-
     # install the python dependencies
     pip install -e .
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import sys
-from setuptools import setup
+from setuptools import setup, find_packages
 
 try:
     from pip._internal.req import parse_requirements
@@ -19,6 +19,6 @@ setup(name='nlg-eval',
       author='Shikhar Sharma, Hannes Schulz',
       author_email='shikhar.sharma@microsoft.com, hannes.schulz@microsoft.com, justin.harris@microsoft.com',
       url='https://github.com/Maluuba/nlg-eval',
-      packages=['nlgeval'],
+      packages=find_packages(),
       scripts=['bin/nlg-eval'],
       install_requires=reqs)

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-import six
+import sys
 from setuptools import setup
 
 try:
@@ -8,7 +8,7 @@ try:
 except:
     from pip.req import parse_requirements
 requirements_path = 'requirements.txt'
-if six.PY2:
+if sys.version_info[0] < 3:
     requirements_path = 'requirements_py2.txt'
 install_reqs = parse_requirements(requirements_path, session=False)
 reqs = [str(ir.req) for ir in install_reqs]


### PR DESCRIPTION
- six can be avoided during setup by using `sys.version_info`. 
- allow installing the module into a system directory (e.g. on a docker) via 
   `pip install git+https://github.com/Maluuba/nlg-eval.git@master`