### PR TITLE
support external data directory (e.g. to mount into docker)

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,13 @@ images, set idf to "coco-val-df" instead, which uses IDF from the MSCOCO Vaildat
 not been adapted in this code. For this use-case, apply patches from
 [vrama91/coco-caption](https://github.com/vrama91/coco-caption).
 
+
+## External data directory
+
+To mount an already prepared data directory into a docker or share it between
+users, you can set the `NLGEVAL_DATA` environment variable to let nlg-eval know
+where to find its models and data.
+
 ## Microsoft Open Source Code of Conduct ##
 This project has adopted the [Microsoft Open Source Code of
 Conduct](https://opensource.microsoft.com/codeofconduct/).

--- a/nlgeval/skipthoughts/skipthoughts.py
+++ b/nlgeval/skipthoughts/skipthoughts.py
@@ -20,8 +20,8 @@ profile = False
 #-----------------------------------------------------------------------------#
 # Specify model and table locations here
 #-----------------------------------------------------------------------------#
-path_to_models = os.path.join(os.path.dirname(__file__), '..', 'data')
-path_to_tables = os.path.join(os.path.dirname(__file__), '..', 'data')
+path_to_models = os.environ.get('NLGEVAL_DATA', os.path.join(os.path.dirname(__file__), '..', 'data'))
+path_to_tables = os.environ.get('NLGEVAL_DATA', os.path.join(os.path.dirname(__file__), '..', 'data'))
 #-----------------------------------------------------------------------------#
 
 path_to_umodel = os.path.join(path_to_models, 'uni_skip.npz')

--- a/nlgeval/word2vec/evaluate.py
+++ b/nlgeval/word2vec/evaluate.py
@@ -10,7 +10,7 @@ except ImportError:
 
 class Embedding(object):
     def __init__(self):
-        path = os.path.join(os.path.dirname(__file__), '..', 'data')
+        path = os.environ.get('NLGEVAL_DATA', os.path.join(os.path.dirname(__file__), '..', 'data'))
         self.m = KeyedVectors.load(os.path.join(path, 'glove.6B.300d.model.bin'), mmap='r')
         try:
             self.unk = self.m.vectors.mean(axis=0)


### PR DESCRIPTION
The `NLGEVAL_DATA` environment variable can be used to point the nlg-eval module to an existing data directory (e.g. mounted into a docker).