### PR TITLE
Modernize Python 2 code to prepare for Python 3

### DIFF
--- a/nlgeval/skipthoughts/dataset_handler.py
+++ b/nlgeval/skipthoughts/dataset_handler.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Dataset handler for binary classification tasks (MR, CR, SUBJ, MQPA)
 
 import numpy as np
@@ -23,7 +24,7 @@ def load_data(encoder, name, loc='./data/', seed=1234):
     text, labels = shuffle_data(pos+neg, labels, seed=seed)
     z['text'] = text
     z['labels'] = labels
-    print 'Computing skip-thought vectors...'
+    print('Computing skip-thought vectors...')
     features = encoder.encode(text, verbose=False)
     return z, features
 

--- a/nlgeval/skipthoughts/decoding/model.py
+++ b/nlgeval/skipthoughts/decoding/model.py
@@ -1,6 +1,7 @@
 """
 Model specification
 """
+from __future__ import print_function
 import theano
 import theano.tensor as tensor
 import numpy
@@ -95,7 +96,7 @@ def build_sampler(tparams, options, trng):
     ctx = tensor.matrix('ctx', dtype='float32')
     ctx0 = ctx
 
-    print 'Building f_init...',
+    print('Building f_init...', end=' ')
     init_state = get_layer('ff')[1](tparams, ctx, options, prefix='ff_state', activ='tanh')
     f_init = theano.function([ctx], init_state, name='f_init', profile=False)
 
@@ -124,11 +125,11 @@ def build_sampler(tparams, options, trng):
     next_sample = trng.multinomial(pvals=next_probs).argmax(1)
 
     # next word probability
-    print 'Building f_next..',
+    print('Building f_next..', end=' ')
     inps = [y, init_state]
     outs = [next_probs, next_sample, next_state]
     f_next = theano.function(inps, outs, name='f_next', profile=False)
-    print 'Done'
+    print('Done')
 
     return f_init, f_next
 

--- a/nlgeval/skipthoughts/decoding/search.py
+++ b/nlgeval/skipthoughts/decoding/search.py
@@ -1,8 +1,11 @@
 """
 Code for sequence generation
 """
-import numpy
 import copy
+
+import numpy
+from six.moves import xrange
+
 
 def gen_sample(tparams, f_init, f_next, ctx, options, trng=None, k=1, maxlen=30,
                stochastic=True, argmax=False, use_unk=False):
@@ -101,5 +104,3 @@ def gen_sample(tparams, f_init, f_next, ctx, options, trng=None, k=1, maxlen=30,
                 sample_score.append(hyp_scores[idx])
 
     return sample, sample_score
-
-

--- a/nlgeval/skipthoughts/decoding/tools.py
+++ b/nlgeval/skipthoughts/decoding/tools.py
@@ -2,6 +2,7 @@
 A selection of functions for the decoder
 Loading models, generating text
 """
+from __future__ import print_function
 import theano
 import theano.tensor as tensor
 from theano.sandbox.rng_mrg import MRG_RandomStreams as RandomStreams
@@ -25,12 +26,12 @@ def load_model():
     Load a trained model for decoding
     """
     # Load the worddict
-    print 'Loading dictionary...'
+    print('Loading dictionary...')
     with open(path_to_dictionary, 'rb') as f:
         worddict = pkl.load(f)
 
     # Create inverted dictionary
-    print 'Creating inverted dictionary...'
+    print('Creating inverted dictionary...')
     word_idict = dict()
     for kk, vv in worddict.iteritems():
         word_idict[vv] = kk
@@ -38,12 +39,12 @@ def load_model():
     word_idict[1] = 'UNK'
 
     # Load model options
-    print 'Loading model options...'
+    print('Loading model options...')
     with open('%s.pkl'%path_to_model, 'rb') as f:
         options = pkl.load(f)
 
     # Load parameters
-    print 'Loading model parameters...'
+    print('Loading model parameters...')
     params = init_params(options)
     params = load_params(path_to_model, params)
     tparams = init_tparams(params)

--- a/nlgeval/skipthoughts/decoding/utils.py
+++ b/nlgeval/skipthoughts/decoding/utils.py
@@ -1,6 +1,8 @@
 """
 Helper functions for skip-thoughts
 """
+import warnings
+
 import theano
 import theano.tensor as tensor
 import numpy
@@ -123,4 +125,3 @@ def concatenate(tensor_list, axis=0):
         offset += tt.shape[axis]
 
     return out
-

--- a/nlgeval/skipthoughts/eval_classification.py
+++ b/nlgeval/skipthoughts/eval_classification.py
@@ -1,9 +1,11 @@
+from __future__ import print_function
+from __future__ import absolute_import
 # Experiment scripts for binary classification benchmarks (e.g. MR, CR, MPQA, SUBJ)
 
 import numpy as np
 import sys
-import nbsvm
-import dataset_handler
+from . import nbsvm
+from . import dataset_handler
 
 from scipy.sparse import hstack
 
@@ -66,7 +68,7 @@ def eval_nested_kfold(encoder, name, loc='./data/', k=10, seed=1234, use_nb=Fals
                 clf.fit(X_innertrain, y_innertrain)
                 acc = clf.score(X_innertest, y_innertest)
                 innerscores.append(acc)
-                print (s, acc)
+                print((s, acc))
 
             # Append mean score
             scanscores.append(np.mean(innerscores))
@@ -74,8 +76,8 @@ def eval_nested_kfold(encoder, name, loc='./data/', k=10, seed=1234, use_nb=Fals
         # Get the index of the best score
         s_ind = np.argmax(scanscores)
         s = scan[s_ind]
-        print scanscores
-        print s
+        print(scanscores)
+        print(s)
  
         # NB (if applicable)
         if use_nb:
@@ -90,7 +92,7 @@ def eval_nested_kfold(encoder, name, loc='./data/', k=10, seed=1234, use_nb=Fals
         # Evaluate
         acc = clf.score(X_test, y_test)
         scores.append(acc)
-        print scores
+        print(scores)
 
     return scores
 

--- a/nlgeval/skipthoughts/eval_msrp.py
+++ b/nlgeval/skipthoughts/eval_msrp.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Evaluation for MSRP
 
 import numpy as np
@@ -17,22 +18,22 @@ def evaluate(encoder, k=10, seed=1234, evalcv=True, evaltest=False, use_feats=Tr
     k: number of CV folds
     test: whether to evaluate on test set
     """
-    print 'Preparing data...'
+    print('Preparing data...')
     traintext, testtext, labels = load_data(loc)
 
-    print 'Computing training skipthoughts...'
+    print('Computing training skipthoughts...')
     trainA = encoder.encode(traintext[0], verbose=False)
     trainB = encoder.encode(traintext[1], verbose=False)
 
     if evalcv:
-        print 'Running cross-validation...'
+        print('Running cross-validation...')
         C = eval_kfold(trainA, trainB, traintext, labels[0], shuffle=True, k=10, seed=1234, use_feats=use_feats)
 
     if evaltest:
         if not evalcv:
             C = 4    # Best parameter found from CV (combine-skip with use_feats=True)
 
-        print 'Computing testing skipthoughts...'
+        print('Computing testing skipthoughts...')
         testA = encoder.encode(testtext[0], verbose=False)
         testB = encoder.encode(testtext[1], verbose=False)
 
@@ -43,12 +44,12 @@ def evaluate(encoder, k=10, seed=1234, evalcv=True, evaltest=False, use_feats=Tr
             train_features = np.c_[np.abs(trainA - trainB), trainA * trainB]
             test_features = np.c_[np.abs(testA - testB), testA * testB]
 
-        print 'Evaluating...'
+        print('Evaluating...')
         clf = LogisticRegression(C=C)
         clf.fit(train_features, labels[0])
         yhat = clf.predict(test_features)
-        print 'Test accuracy: ' + str(clf.score(test_features, labels[1]))
-        print 'Test F1: ' + str(f1(labels[1], yhat))
+        print('Test accuracy: ' + str(clf.score(test_features, labels[1])))
+        print('Test F1: ' + str(f1(labels[1], yhat)))
 
 
 def load_data(loc='./data/'):
@@ -167,17 +168,17 @@ def eval_kfold(A, B, train, labels, shuffle=True, k=10, seed=1234, use_feats=Fal
             yhat = clf.predict(X_test)
             fscore = f1(y_test, yhat)
             scanscores.append(fscore)
-            print (s, fscore)
+            print((s, fscore))
 
         # Append mean score
         scores.append(np.mean(scanscores))
-        print scores
+        print(scores)
 
     # Get the index of the best score
     s_ind = np.argmax(scores)
     s = scan[s_ind]
-    print scores
-    print s
+    print(scores)
+    print(s)
     return s
 
 

--- a/nlgeval/skipthoughts/eval_rank.py
+++ b/nlgeval/skipthoughts/eval_rank.py
@@ -1,6 +1,7 @@
 '''
 Evaluation code for image-sentence ranking
 '''
+from __future__ import print_function
 import numpy as np
 
 import theano
@@ -223,7 +224,7 @@ def validate_options(options):
 
 # Load a saved model and evaluate the results
 def evaluate(X, saveto, evaluate=False, out=False):
-    print "Loading model..."
+    print("Loading model...")
     with open('%s.pkl'%saveto, 'rb') as f:
         model_options = pkl.load(f)
 
@@ -231,18 +232,18 @@ def evaluate(X, saveto, evaluate=False, out=False):
     params = load_params(saveto, params)
     tparams = init_tparams(params)
 
-    print 'Building encoder'
+    print('Building encoder')
     inps_e, lim, ls = build_encoder(tparams, model_options)
     f_emb = theano.function(inps_e, [lim, ls], profile=False)
 
-    print 'Compute embeddings...'
+    print('Compute embeddings...')
     lim, ls = f_emb(X[1], X[2])
 
     if evaluate:
         (r1, r5, r10, medr) = i2t(lim, ls)
-        print "Image to text: %.1f, %.1f, %.1f, %.1f" % (r1, r5, r10, medr)
+        print("Image to text: %.1f, %.1f, %.1f, %.1f" % (r1, r5, r10, medr))
         (r1i, r5i, r10i, medri) = t2i(lim, ls)
-        print "Text to image: %.1f, %.1f, %.1f, %.1f" % (r1i, r5i, r10i, medri)
+        print("Text to image: %.1f, %.1f, %.1f, %.1f" % (r1i, r5i, r10i, medri))
     if out:
         return lim, ls
 
@@ -283,39 +284,39 @@ def trainer(train, dev, # training and development tuples
     model_options['reload_'] = reload_
 
     model_options = validate_options(model_options)
-    print model_options
+    print(model_options)
 
     # reload options
     if reload_ and os.path.exists(saveto):
-        print "Reloading options"
+        print("Reloading options")
         with open('%s.pkl'%saveto, 'rb') as f:
             model_options = pkl.load(f)
 
-    print 'Building model'
+    print('Building model')
     params = init_params(model_options)
     # reload parameters
     if reload_ and os.path.exists(saveto):
-        print "Reloading model"
+        print("Reloading model")
         params = load_params(saveto, params)
 
     tparams = init_tparams(params)
 
     inps, cost = build_model(tparams, model_options)
 
-    print 'Building encoder'
+    print('Building encoder')
     inps_e, lim, ls = build_encoder(tparams, model_options)
 
-    print 'Building functions'
+    print('Building functions')
     f_cost = theano.function(inps, -cost, profile=False)
     f_emb = theano.function(inps_e, [lim, ls], profile=False)
 
     # gradient computation
-    print 'Computing gradients'
+    print('Computing gradients')
     grads = tensor.grad(cost, wrt=itemlist(tparams))
     lr = tensor.scalar(name='lr')
     f_grad_shared, f_update = eval(optimizer)(lr, tparams, grads, inps, cost)
 
-    print 'Optimization'
+    print('Optimization')
 
     uidx = 0
     estop = False
@@ -354,27 +355,27 @@ def trainer(train, dev, # training and development tuples
             ud_duration = time.time() - ud_start
 
             if numpy.mod(uidx, dispFreq) == 0:
-                print 'Epoch ', eidx, 'Update ', uidx, 'Cost ', cost, 'UD ', ud_duration
+                print('Epoch ', eidx, 'Update ', uidx, 'Cost ', cost, 'UD ', ud_duration)
 
             if numpy.mod(uidx, validFreq) == 0:
 
-                print 'Computing ranks...'
+                print('Computing ranks...')
                 lim, ls = f_emb(dev[1], dev[2])
                 (r1, r5, r10, medr) = i2t(lim, ls)
-                print "Image to text: %.1f, %.1f, %.1f, %.1f" % (r1, r5, r10, medr)
+                print("Image to text: %.1f, %.1f, %.1f, %.1f" % (r1, r5, r10, medr))
                 (r1i, r5i, r10i, medri) = t2i(lim, ls)
-                print "Text to image: %.1f, %.1f, %.1f, %.1f" % (r1i, r5i, r10i, medri)
+                print("Text to image: %.1f, %.1f, %.1f, %.1f" % (r1i, r5i, r10i, medri))
 
                 currscore = r1 + r5 + r10 + r1i + r5i + r10i
                 if currscore > curr:
                     curr = currscore
 
                     # Save model
-                    print 'Saving...',
+                    print('Saving...', end=' ')
                     params = unzip(tparams)
                     numpy.savez(saveto, history_errs=history_errs, **params)
                     pkl.dump(model_options, open('%s.pkl'%saveto, 'wb'))
-                    print 'Done'
+                    print('Done')
 
 
 def i2t(images, captions, npts=None):

--- a/nlgeval/skipthoughts/eval_sick.py
+++ b/nlgeval/skipthoughts/eval_sick.py
@@ -1,6 +1,7 @@
 '''
 Evaluation code for the SICK dataset (SemEval 2014 Task 1)
 '''
+from __future__ import print_function
 import numpy as np
 import os.path
 from sklearn.metrics import mean_squared_error as mse
@@ -17,49 +18,49 @@ def evaluate(encoder, seed=1234, evaltest=False, loc='./data/'):
     """
     Run experiment
     """
-    print 'Preparing data...'
+    print('Preparing data...')
     train, dev, test, scores = load_data(loc)
     train[0], train[1], scores[0] = shuffle(train[0], train[1], scores[0], random_state=seed)
     
-    print 'Computing training skipthoughts...'
+    print('Computing training skipthoughts...')
     trainA = encoder.encode(train[0], verbose=False, use_eos=True)
     trainB = encoder.encode(train[1], verbose=False, use_eos=True)
     
-    print 'Computing development skipthoughts...'
+    print('Computing development skipthoughts...')
     devA = encoder.encode(dev[0], verbose=False, use_eos=True)
     devB = encoder.encode(dev[1], verbose=False, use_eos=True)
 
-    print 'Computing feature combinations...'
+    print('Computing feature combinations...')
     trainF = np.c_[np.abs(trainA - trainB), trainA * trainB]
     devF = np.c_[np.abs(devA - devB), devA * devB]
 
-    print 'Encoding labels...'
+    print('Encoding labels...')
     trainY = encode_labels(scores[0])
     devY = encode_labels(scores[1])
 
-    print 'Compiling model...'
+    print('Compiling model...')
     lrmodel = prepare_model(ninputs=trainF.shape[1])
 
-    print 'Training...'
+    print('Training...')
     bestlrmodel = train_model(lrmodel, trainF, trainY, devF, devY, scores[1])
 
     if evaltest:
-        print 'Computing test skipthoughts...'
+        print('Computing test skipthoughts...')
         testA = encoder.encode(test[0], verbose=False, use_eos=True)
         testB = encoder.encode(test[1], verbose=False, use_eos=True)
 
-        print 'Computing feature combinations...'
+        print('Computing feature combinations...')
         testF = np.c_[np.abs(testA - testB), testA * testB]
 
-        print 'Evaluating...'
+        print('Evaluating...')
         r = np.arange(1,6)
         yhat = np.dot(bestlrmodel.predict_proba(testF, verbose=2), r)
         pr = pearsonr(yhat, scores[2])[0]
         sr = spearmanr(yhat, scores[2])[0]
         se = mse(yhat, scores[2])
-        print 'Test Pearson: ' + str(pr)
-        print 'Test Spearman: ' + str(sr)
-        print 'Test MSE: ' + str(se)
+        print('Test Pearson: ' + str(pr))
+        print('Test Spearman: ' + str(sr))
+        print('Test MSE: ' + str(se))
 
         return yhat
 
@@ -89,7 +90,7 @@ def train_model(lrmodel, X, Y, devX, devY, devscores):
         yhat = np.dot(lrmodel.predict_proba(devX, verbose=2), r)
         score = pearsonr(yhat, devscores)[0]
         if score > best:
-            print score
+            print(score)
             best = score
             bestlrmodel = prepare_model(ninputs=X.shape[1])
             bestlrmodel.set_weights(lrmodel.get_weights())
@@ -98,7 +99,7 @@ def train_model(lrmodel, X, Y, devX, devY, devscores):
 
     yhat = np.dot(bestlrmodel.predict_proba(devX, verbose=2), r)
     score = pearsonr(yhat, devscores)[0]
-    print 'Dev Pearson: ' + str(score)
+    print('Dev Pearson: ' + str(score))
     return bestlrmodel
     
 

--- a/nlgeval/skipthoughts/eval_trec.py
+++ b/nlgeval/skipthoughts/eval_trec.py
@@ -1,6 +1,7 @@
 '''
 Evaluation code for the TREC dataset
 '''
+from __future__ import print_function
 import numpy as np
 import os.path
 from sklearn.linear_model import LogisticRegression
@@ -14,7 +15,7 @@ def evaluate(encoder, k=10, seed=1234, evalcv=True, evaltest=False, loc='./data/
     k: number of CV folds
     test: whether to evaluate on test set
     """
-    print 'Preparing data...'
+    print('Preparing data...')
     traintext, testtext = load_data(loc)
     train, train_labels = prepare_data(traintext)
     test, test_labels = prepare_data(testtext)
@@ -22,11 +23,11 @@ def evaluate(encoder, k=10, seed=1234, evalcv=True, evaltest=False, loc='./data/
     test_labels = prepare_labels(test_labels)
     train, train_labels = shuffle(train, train_labels, random_state=seed)
 
-    print 'Computing training skipthoughts...'
+    print('Computing training skipthoughts...')
     trainF = encoder.encode(train, verbose=False, use_eos=False)
     
     if evalcv:
-        print 'Running cross-validation...'
+        print('Running cross-validation...')
         interval = [2**t for t in range(0,9,1)]     # coarse-grained
         C = eval_kfold(trainF, train_labels, k=k, scan=interval, seed=seed)
 
@@ -34,14 +35,14 @@ def evaluate(encoder, k=10, seed=1234, evalcv=True, evaltest=False, loc='./data/
         if not evalcv:
             C = 128     # Best parameter found from CV
 
-        print 'Computing testing skipthoughts...'
+        print('Computing testing skipthoughts...')
         testF = encoder.encode(test, verbose=False, use_eos=False)
 
-        print 'Evaluating...'
+        print('Evaluating...')
         clf = LogisticRegression(C=C)
         clf.fit(trainF, train_labels)
         yhat = clf.predict(testF)
-        print 'Test accuracy: ' + str(clf.score(testF, test_labels))
+        print('Test accuracy: ' + str(clf.score(testF, test_labels)))
 
 
 def load_data(loc='./data/'):
@@ -108,15 +109,15 @@ def eval_kfold(features, labels, k=10, scan=[2**t for t in range(0,9,1)], seed=1
             clf.fit(X_train, y_train)
             score = clf.score(X_test, y_test)
             scanscores.append(score)
-            print (s, score)
+            print((s, score))
 
         # Append mean score
         scores.append(np.mean(scanscores))
-        print scores
+        print(scores)
 
     # Get the index of the best score
     s_ind = np.argmax(scores)
     s = scan[s_ind]
-    print (s_ind, s)
+    print((s_ind, s))
     return s
 

--- a/nlgeval/skipthoughts/training/tools.py
+++ b/nlgeval/skipthoughts/training/tools.py
@@ -2,6 +2,7 @@
 A selection of functions for extracting vectors
 Encoder + vocab expansion
 """
+from __future__ import print_function
 import theano
 import theano.tensor as tensor
 from theano.sandbox.rng_mrg import MRG_RandomStreams as RandomStreams
@@ -32,12 +33,12 @@ def load_model(embed_map=None):
     Load all model components + apply vocab expansion
     """
     # Load the worddict
-    print 'Loading dictionary...'
+    print('Loading dictionary...')
     with open(path_to_dictionary, 'rb') as f:
         worddict = pkl.load(f)
 
     # Create inverted dictionary
-    print 'Creating inverted dictionary...'
+    print('Creating inverted dictionary...')
     word_idict = dict()
     for kk, vv in worddict.iteritems():
         word_idict[vv] = kk
@@ -45,18 +46,18 @@ def load_model(embed_map=None):
     word_idict[1] = 'UNK'
 
     # Load model options
-    print 'Loading model options...'
+    print('Loading model options...')
     with open('%s.pkl'%path_to_model, 'rb') as f:
         options = pkl.load(f)
 
     # Load parameters
-    print 'Loading model parameters...'
+    print('Loading model parameters...')
     params = init_params(options)
     params = load_params(path_to_model, params)
     tparams = init_tparams(params)
 
     # Extractor functions
-    print 'Compiling encoder...'
+    print('Compiling encoder...')
     trng = RandomStreams(1234)
     trng, x, x_mask, ctx, emb = build_encoder(tparams, options)
     f_enc = theano.function([x, x_mask], ctx, name='f_enc')
@@ -66,15 +67,15 @@ def load_model(embed_map=None):
 
     # Load word2vec, if applicable
     if embed_map == None:
-        print 'Loading word2vec embeddings...'
+        print('Loading word2vec embeddings...')
         embed_map = load_googlenews_vectors(path_to_word2vec)
 
     # Lookup table using vocab expansion trick
-    print 'Creating word lookup tables...'
+    print('Creating word lookup tables...')
     table = lookup_table(options, embed_map, worddict, word_idict, f_emb)
 
     # Store everything we need in a dictionary
-    print 'Packing up...'
+    print('Packing up...')
     model = {}
     model['options'] = options
     model['table'] = table
@@ -104,7 +105,7 @@ def encode(model, X, use_norm=True, verbose=True, batch_size=128, use_eos=False)
     # Get features. This encodes by length, in order to avoid wasting computation
     for k in ds.keys():
         if verbose:
-            print k
+            print(k)
         numbatches = len(ds[k]) / batch_size + 1
         for minibatch in range(numbatches):
             caps = ds[k][minibatch::numbatches]

--- a/nlgeval/skipthoughts/training/train.py
+++ b/nlgeval/skipthoughts/training/train.py
@@ -1,6 +1,7 @@
 """
 Main trainer function
 """
+from __future__ import print_function
 import theano
 import theano.tensor as tensor
 
@@ -61,16 +62,16 @@ def trainer(X,
     model_options['saveFreq'] = saveFreq
     model_options['reload_'] = reload_
 
-    print model_options
+    print(model_options)
 
     # reload options
     if reload_ and os.path.exists(saveto):
-        print 'reloading...' + saveto
+        print('reloading...' + saveto)
         with open('%s.pkl'%saveto, 'rb') as f:
             models_options = pkl.load(f)
 
     # load dictionary
-    print 'Loading dictionary...'
+    print('Loading dictionary...')
     worddict = load_dictionary(dictionary)
 
     # Inverse dictionary
@@ -80,7 +81,7 @@ def trainer(X,
     word_idict[0] = '<eos>'
     word_idict[1] = 'UNK'
 
-    print 'Building model'
+    print('Building model')
     params = init_params(model_options)
     # reload parameters
     if reload_ and os.path.exists(saveto):
@@ -95,9 +96,9 @@ def trainer(X,
     inps = [x, x_mask, y, y_mask, z, z_mask]
 
     # before any regularizer
-    print 'Building f_log_probs...',
+    print('Building f_log_probs...', end=' ')
     f_log_probs = theano.function(inps, cost, profile=False)
-    print 'Done'
+    print('Done')
 
     # weight decay, if applicable
     if decay_c > 0.:
@@ -109,12 +110,12 @@ def trainer(X,
         cost += weight_decay
 
     # after any regularizer
-    print 'Building f_cost...',
+    print('Building f_cost...', end=' ')
     f_cost = theano.function(inps, cost, profile=False)
-    print 'Done'
+    print('Done')
 
-    print 'Done'
-    print 'Building f_grad...',
+    print('Done')
+    print('Building f_grad...', end=' ')
     grads = tensor.grad(cost, wrt=itemlist(tparams))
     f_grad_norm = theano.function(inps, [(g**2).sum() for g in grads], profile=False)
     f_weight_norm = theano.function([], [(t**2).sum() for k,t in tparams.iteritems()], profile=False)
@@ -131,11 +132,11 @@ def trainer(X,
         grads = new_grads
 
     lr = tensor.scalar(name='lr')
-    print 'Building optimizers...',
+    print('Building optimizers...', end=' ')
     # (compute gradients), (updates parameters)
     f_grad_shared, f_update = eval(optimizer)(lr, tparams, grads, inps, cost)
 
-    print 'Optimization'
+    print('Optimization')
 
     # Each sentence in the minibatch have same length (for encoder)
     trainX = homogeneous_data.grouper(X)
@@ -146,7 +147,7 @@ def trainer(X,
     for eidx in xrange(max_epochs):
         n_samples = 0
 
-        print 'Epoch ', eidx
+        print('Epoch ', eidx)
 
         for x, y, z in train_iter:
             n_samples += len(x)
@@ -155,7 +156,7 @@ def trainer(X,
             x, x_mask, y, y_mask, z, z_mask = homogeneous_data.prepare_data(x, y, z, worddict, maxlen=maxlen_w, n_words=n_words)
 
             if x == None:
-                print 'Minibatch with zero sample under length ', maxlen_w
+                print('Minibatch with zero sample under length ', maxlen_w)
                 uidx -= 1
                 continue
 
@@ -165,21 +166,21 @@ def trainer(X,
             ud = time.time() - ud_start
 
             if numpy.isnan(cost) or numpy.isinf(cost):
-                print 'NaN detected'
+                print('NaN detected')
                 return 1., 1., 1.
 
             if numpy.mod(uidx, dispFreq) == 0:
-                print 'Epoch ', eidx, 'Update ', uidx, 'Cost ', cost, 'UD ', ud
+                print('Epoch ', eidx, 'Update ', uidx, 'Cost ', cost, 'UD ', ud)
 
             if numpy.mod(uidx, saveFreq) == 0:
-                print 'Saving...',
+                print('Saving...', end=' ')
 
                 params = unzip(tparams)
                 numpy.savez(saveto, history_errs=[], **params)
                 pkl.dump(model_options, open('%s.pkl'%saveto, 'wb'))
-                print 'Done'
+                print('Done')
 
-        print 'Seen %d samples'%n_samples
+        print('Seen %d samples'%n_samples)
 
 if __name__ == '__main__':
     pass

--- a/nlgeval/skipthoughts/training/utils.py
+++ b/nlgeval/skipthoughts/training/utils.py
@@ -1,6 +1,8 @@
 """
 Helper functions for skip-thoughts
 """
+import warnings
+
 import theano
 import theano.tensor as tensor
 import numpy
@@ -117,4 +119,3 @@ def concatenate(tensor_list, axis=0):
         offset += tt.shape[axis]
 
     return out
-


### PR DESCRIPTION
Fixes #28 

$ __futurize --stage1 -w .__  # http://python-future.org/futurize_cheatsheet.html

Minimal, safe changes required to make this code syntax compatible with both Python 2 and Python 3. More changes may be required to complete the port to Python 3 but this should provide a solid start in that process without breaking backward compatibility with legacy Python.

