### PR TITLE
FIX confused usage of parameters and variables

### DIFF
--- a/nlgeval/__init__.py
+++ b/nlgeval/__init__.py
@@ -37,7 +37,7 @@ def compute_metrics(hypothesis, references, no_overlap=False, no_skipthoughts=Fa
             (Cider(), "CIDEr")
         ]
         for scorer, method in scorers:
-            score, scores = scorer.compute_score(refs, hyps)
+            score, scores = scorer.compute_score(hyps, refs)
             if isinstance(method, list):
                 for sc, scs, m in zip(score, scores, method):
                     print("%s: %0.6f" % (m, sc))
@@ -102,7 +102,7 @@ def compute_individual_metrics(ref, hyp, no_overlap=False, no_skipthoughts=False
             (Cider(), "CIDEr")
         ]
         for scorer, method in scorers:
-            score, scores = scorer.compute_score(refs, hyps)
+            score, scores = scorer.compute_score(hyps, refs)
             if isinstance(method, list):
                 for sc, scs, m in zip(score, scores, method):
                     ret_scores[m] = sc
@@ -246,7 +246,7 @@ class NLGEval(object):
         ret_scores = {}
         if not self.no_overlap:
             for scorer, method in self.scorers:
-                score, scores = scorer.compute_score(refs, hyps)
+                score, scores = scorer.compute_score(hyps, refs)
                 if isinstance(method, list):
                     for sc, scs, m in zip(score, scores, method):
                         ret_scores[m] = sc
@@ -284,7 +284,7 @@ class NLGEval(object):
         ret_scores = {}
         if not self.no_overlap:
             for scorer, method in self.scorers:
-                score, scores = scorer.compute_score(refs, hyps)
+                score, scores = scorer.compute_score(hyps, refs)
                 if isinstance(method, list):
                     for sc, scs, m in zip(score, scores, method):
                         ret_scores[m] = sc

--- a/nlgeval/pycocoevalcap/bleu/bleu.py
+++ b/nlgeval/pycocoevalcap/bleu/bleu.py
@@ -25,8 +25,8 @@ class Bleu:
 
         bleu_scorer = BleuScorer(n=self._n)
         for id in imgIds:
-            hypo = res[id]
-            ref = gts[id]
+            hypo = gts[id]
+            ref = res[id]
 
             # Sanity check.
             assert(type(hypo) is list)

--- a/nlgeval/pycocoevalcap/cider/cider.py
+++ b/nlgeval/pycocoevalcap/cider/cider.py
@@ -35,8 +35,8 @@ class Cider:
         cider_scorer = CiderScorer(n=self._n, sigma=self._sigma)
 
         for id in imgIds:
-            hypo = res[id]
-            ref = gts[id]
+            hypo = gts[id]
+            ref = res[id]
 
             # Sanity check.
             assert(type(hypo) is list)

--- a/nlgeval/pycocoevalcap/meteor/meteor.py
+++ b/nlgeval/pycocoevalcap/meteor/meteor.py
@@ -58,8 +58,8 @@ class Meteor:
         eval_line = 'EVAL'
         with self.lock:
             for i in imgIds:
-                assert (len(res[i]) == 1)
-                stat = self._stat(res[i][0], gts[i])
+                assert (len(gts[i]) == 1)
+                stat = self._stat(gts[i][0], res[i])
                 eval_line += ' ||| {}'.format(stat)
 
             self.meteor_p.stdin.write(enc('{}\n'.format(eval_line)))

--- a/nlgeval/pycocoevalcap/rouge/rouge.py
+++ b/nlgeval/pycocoevalcap/rouge/rouge.py
@@ -87,8 +87,8 @@ class Rouge():
 
         score = []
         for id in imgIds:
-            hypo = res[id]
-            ref  = gts[id]
+            hypo = gts[id]
+            ref  = res[id]
 
             score.append(self.calc_score(hypo, ref))
 


### PR DESCRIPTION
The usage of parameters in `compute_score(self, gts, res)` of each Scorers is confused. `gts` should be short for "generated sentences" and `res` should be short for "reference sentences". However, the callers of these functions assign `refs` to `gts` and `hyps` to `res`, which are inconsistent with the meaning of their names.  Fortunately, it doesn't result in any error because `gts` has been assigned to `ref` and `res` has been assigned to `hypo` in the body of `compute_score(self, gts, res)`. I think we'd better keep the usage of the variables consistence with the meaning of their names.

I have tested the changes with `Bleu`, `METEOR`, `ROUGE_L` and 'CIDEr'. But I didn't test it with remain metrics due to the lack of enough memory to run these models.

By the way, the parameters' order of two public API, `compute_metrics(hypothesis, references,)` and `compute_individual_metrics(ref, hyp)`,  is also inconsistent. I don't change them, because  these changes will result in compatible issues.