### PR TITLE
Fix multithreading bug on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ Then run:
 # It may take a while to run because it's downloading some files. You can instead run `pip install -v -e .` to see more details.
 pip install -e .
 
+# If using macOS High Sierra or higher, run this before run setup, to allow multithreading
+# export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
+
 # Download required data files.
 nlg-eval --setup
 ```


### PR DESCRIPTION
I run `nlg-eval --setup` but failed on macOS Mojave 10.14.3 

Acccodring to [this answer](https://stackoverflow.com/a/52230415), I have to run `export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES` if I'm using macOS High Sierra or higher.

So I update the README incase anyone else has the same problem.