### PR TITLE
fixing bug of wrong position for assignment in NLGEval.compute_metrics

### DIFF
--- a/nlgeval/__init__.py
+++ b/nlgeval/__init__.py
@@ -280,7 +280,7 @@ class NLGEval(object):
         refs = {idx: strippedlines for (idx, strippedlines) in enumerate(ref_list)}
         hyps = {idx: [lines.strip()] for (idx, lines) in enumerate(hyp_list)}
 
-        ref_list = [list(map(_strip, refs)) for refs in zip(*ref_list)]
+        ref_list = [list(map(_strip, ref)) for ref in zip(*ref_list)]
         
         assert len(refs) == len(hyps)
 

--- a/nlgeval/__init__.py
+++ b/nlgeval/__init__.py
@@ -276,9 +276,12 @@ class NLGEval(object):
         return ret_scores
 
     def compute_metrics(self, ref_list, hyp_list):
-        ref_list = [list(map(_strip, refs)) for refs in zip(*ref_list)]
+        
         refs = {idx: strippedlines for (idx, strippedlines) in enumerate(ref_list)}
         hyps = {idx: [lines.strip()] for (idx, lines) in enumerate(hyp_list)}
+
+        ref_list = [list(map(_strip, refs)) for refs in zip(*ref_list)]
+        
         assert len(refs) == len(hyps)
 
         ret_scores = {}


### PR DESCRIPTION
There is a bug in NLGEval.compute_metrics where assignment ref_list before calculating refs and hyps always will fail at the assert.

Original code:
```
def compute_metrics(self, ref_list, hyp_list):
        ref_list = [list(map(_strip, refs)) for refs in zip(*ref_list)]
        refs = {idx: strippedlines for (idx, strippedlines) in enumerate(ref_list)}
        hyps = {idx: [lines.strip()] for (idx, lines) in enumerate(hyp_list)}
        assert len(refs) == len(hyps)

```
Modified code:
```
def compute_metrics(self, ref_list, hyp_list):
       refs = {idx: strippedlines for (idx, strippedlines) in enumerate(ref_list)}
       hyps = {idx: [lines.strip()] for (idx, lines) in enumerate(hyp_list)}

       ref_list = [list(map(_strip, ref)) for ref in zip(*ref_list)]
       assert len(refs) == len(hyps)

```

