### PR TITLE
Fix calculation error when ref is empty

### DIFF
--- a/nlgeval/__init__.py
+++ b/nlgeval/__init__.py
@@ -88,7 +88,7 @@ def compute_individual_metrics(ref, hyp, no_overlap=False, no_skipthoughts=False
 
     if isinstance(ref, six.string_types):
         ref = ref.split('||<|>||')  # special delimiter for backward compatibility
-    ref = [a.strip() for a in ref]
+    ref = [a.strip() for a in ref if len(a.strip()) > 0]
     refs = {0: ref}
     ref_list = [ref]
 
@@ -225,7 +225,6 @@ class NLGEval(object):
         if 'CIDEr' not in self.metrics_to_omit:
             self.scorers.append((Cider(), "CIDEr"))
 
-
     def load_skipthought_model(self):
         from nlgeval.skipthoughts import skipthoughts
         import numpy as np
@@ -246,7 +245,7 @@ class NLGEval(object):
 
     def compute_individual_metrics(self, ref, hyp):
         assert isinstance(hyp, six.string_types)
-        ref = [a.strip() for a in ref]
+        ref = [a.strip() for a in ref if len(a.strip()) > 0]
         refs = {0: ref}
         ref_list = [ref]
 
@@ -254,6 +253,7 @@ class NLGEval(object):
         hyp_list = [hyp]
 
         ret_scores = {}
+
         if not self.no_overlap:
             for scorer, method in self.scorers:
                 score, scores = scorer.compute_score(refs, hyps)
@@ -266,8 +266,10 @@ class NLGEval(object):
         if not self.no_skipthoughts:
             vector_hyps = self.skipthought_encoder.encode([h.strip() for h in hyp_list], verbose=False)
             ref_list_T = self.np.array(ref_list).T.tolist()
-            vector_refs = map(lambda refl: self.skipthought_encoder.encode([r.strip() for r in refl], verbose=False), ref_list_T)
-            cosine_similarity = list(map(lambda refv: self.cosine_similarity(refv, vector_hyps).diagonal(), vector_refs))
+            vector_refs = map(lambda refl: self.skipthought_encoder.encode([r.strip() for r in refl], verbose=False),
+                              ref_list_T)
+            cosine_similarity = list(
+                map(lambda refv: self.cosine_similarity(refv, vector_hyps).diagonal(), vector_refs))
             cosine_similarity = self.np.max(cosine_similarity, axis=0).mean()
             ret_scores['SkipThoughtCS'] = cosine_similarity
 
@@ -304,8 +306,10 @@ class NLGEval(object):
         if not self.no_skipthoughts:
             vector_hyps = self.skipthought_encoder.encode([h.strip() for h in hyp_list], verbose=False)
             ref_list_T = self.np.array(ref_list).T.tolist()
-            vector_refs = map(lambda refl: self.skipthought_encoder.encode([r.strip() for r in refl], verbose=False), ref_list_T)
-            cosine_similarity = list(map(lambda refv: self.cosine_similarity(refv, vector_hyps).diagonal(), vector_refs))
+            vector_refs = map(lambda refl: self.skipthought_encoder.encode([r.strip() for r in refl], verbose=False),
+                              ref_list_T)
+            cosine_similarity = list(
+                map(lambda refv: self.cosine_similarity(refv, vector_hyps).diagonal(), vector_refs))
             cosine_similarity = self.np.max(cosine_similarity, axis=0).mean()
             ret_scores['SkipThoughtCS'] = cosine_similarity
 

--- a/nlgeval/tests/test_nlgeval.py
+++ b/nlgeval/tests/test_nlgeval.py
@@ -103,6 +103,27 @@ class TestNlgEval(unittest.TestCase):
         self.assertAlmostEqual(0.960771, scores['GreedyMatchingScore'], places=5)
         self.assertEqual(7, len(scores))
 
+    def test_compute_metrics_empty(self):
+        n = NLGEval()
+
+        # Individual Metrics
+        scores = n.compute_individual_metrics(ref=["this is a test",
+                                                   ""],
+                                              hyp="this is a good test")
+        self.assertAlmostEqual(0.799999, scores['Bleu_1'], places=5)
+        self.assertAlmostEqual(0.632455, scores['Bleu_2'], places=5)
+        self.assertAlmostEqual(0.5108729, scores['Bleu_3'], places=5)
+        self.assertAlmostEqual(0.0000903602, scores['Bleu_4'], places=5)
+        self.assertAlmostEqual(0.44434387, scores['METEOR'], places=5)
+        self.assertAlmostEqual(0.9070631, scores['ROUGE_L'], places=5)
+        self.assertAlmostEqual(0.0, scores['CIDEr'], places=5)
+        self.assertAlmostEqual(0.8375251, scores['SkipThoughtCS'], places=5)
+        self.assertAlmostEqual(0.980075, scores['EmbeddingAverageCosineSimilarity'], places=5)
+        self.assertEqual(scores['EmbeddingAverageCosineSimilarity'], scores['EmbeddingAverageCosineSimilairty'])
+        self.assertAlmostEqual(0.94509, scores['VectorExtremaCosineSimilarity'], places=5)
+        self.assertAlmostEqual(0.960771, scores['GreedyMatchingScore'], places=5)
+        self.assertEqual(12, len(scores))
+
     def test_compute_metrics(self):
         # The example from the README.
         root_dir = os.path.join(os.path.dirname(__file__), '..', '..')


### PR DESCRIPTION
This pull request fixing the issue that any of the ref is empty

When the number of ref is inconsistent, i will fill a empty string as padding. which causing an error.

```
scores = n.compute_metrics(ref_list=[
            [
                "this is one reference sentence for sentence1",
                ""
            ],
            [
                "this is one more reference sentence for sentence1",
                "this is the second reference sentence for sentence2"
            ],
        ],
            hyp_list=[
                "this is the model generated sentence1 which seems good enough",
                "this is sentence2 which has been generated by your model"
            ]
        )
```