### PR TITLE
attempt to fix travis build by depending on Cython explicitly

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ numpy>=1.11.0
 psutil>=5.6.2
 requests>=2.19
 six>=1.11
+Cython>=0.28.5
 scipy>=0.17.0
 scikit-learn>=0.17
 gensim>=3

--- a/requirements_py2.txt
+++ b/requirements_py2.txt
@@ -4,6 +4,7 @@ numpy>=1.11.0<=1.17
 psutil>=5.6.2
 requests>=2.19
 six>=1.11
+Cython>=0.28.5
 scipy>=0.17.0
 scikit-learn<0.21
 gensim<1


### PR DESCRIPTION
it seems that [sklean implicitly depends on Cython](https://github.com/scikit-learn/scikit-learn/issues/19068) without making this requirement explicit.