### PR TITLE
remove dependency on pip from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,21 +10,13 @@ from setuptools import setup
 from setuptools.command.develop import develop
 from setuptools.command.install import install
 
-try:
-    from pip._internal.req import parse_requirements
-except:
-    from pip.req import parse_requirements
-
 
 if __name__ == '__main__':
     requirements_path = 'requirements.txt'
     if sys.version_info[0] < 3:
         requirements_path = 'requirements_py2.txt'
-    install_reqs = parse_requirements(requirements_path, session=False)
-    try:
-        reqs = [str(ir.req) for ir in install_reqs]
-    except:
-        reqs = [str(ir.requirement) for ir in install_reqs]
+    with open(requirements_path) as f:
+        install_reqs = f.read().splitlines()
 
     setup(name='nlg-eval',
           version='2.4.1',
@@ -35,5 +27,5 @@ if __name__ == '__main__':
           packages=find_packages(),
           include_package_data=True,
           scripts=['bin/nlg-eval'],
-          install_requires=reqs,
+          install_requires=install_reqs,
     )


### PR DESCRIPTION
We use `nlg-eval` in a monorepo built by Bazel using [rules_python](https://github.com/bazelbuild/rules_python). It looks like, while updating from `rules_python` 0.25.0 to 0.27.1, `pip` is not available anymore in the environment building external packages. This breaks the build of `nlg-eval` since it imports `pip` in its `setup.py`. This is discouraged by PyPA members [here](https://github.com/pypa/pip/issues/2286#issuecomment-68285791) for example, so looks to be an issue with `nlg-eval` rather than with `rules_python`.

Remove the dependency of the `setup.py` on `pip` and instead simply read the list of requirements from the requirements-files. This method can't handle more complex constructs in the requirements-file, but is good enough here. Similar solutions have been used in other places, see the related PRs to the discussion linked above.